### PR TITLE
Fix windows build

### DIFF
--- a/boltbrowser.go
+++ b/boltbrowser.go
@@ -25,12 +25,6 @@ func mainLoop(memBolt *BoltDB, style Style) {
 	for {
 		event := termbox.PollEvent()
 		if event.Type == termbox.EventKey {
-			if event.Key == termbox.KeyCtrlZ {
-				process, _ := os.FindProcess(os.Getpid())
-				termbox.Close()
-				process.Signal(syscall.SIGSTOP)
-				termbox.Init()
-			}
 			newScreenIndex := displayScreen.handleKeyEvent(event)
 			if newScreenIndex < len(screens) {
 				displayScreen = screens[newScreenIndex]


### PR DESCRIPTION
No UNIX signals are defined under windows, so Ctrl-Z sending SIGSTOP to self is removed.