### PR TITLE
Consider allowing compiler to reassign the value of ProgramName

### DIFF
--- a/boltbrowser.go
+++ b/boltbrowser.go
@@ -11,7 +11,7 @@ import (
 /*
 ProgramName is the name of the program
 */
-const ProgramName = "boltbrowser"
+var ProgramName = "boltbrowser"
 
 var databaseFile string
 var db *bolt.DB


### PR DESCRIPTION
Can use ldflags in build line such as:

    -ldflags='-X main.ProgramName=${NAME}"'