### PR TITLE
handle non-bolt files with a simple error screen

### DIFF
--- a/boltbrowser.go
+++ b/boltbrowser.go
@@ -32,7 +32,6 @@ func main() {
 		panic(err)
 	}
 	defer termbox.Close()
-
 	style := defaultStyle()
 	termbox.SetOutputMode(termbox.Output256)
 
@@ -41,8 +40,14 @@ func main() {
 		currentFilename = databaseFile
 		db, err = bolt.Open(databaseFile, 0600, nil)
 		if err != nil {
-			mainLoop(nil, style)
-			continue
+			if len(databaseFiles) > 1 {
+				mainLoop(nil, style)
+				continue
+			} else {
+				termbox.Close()
+				fmt.Printf("Error reading file: %q\n", err.Error())
+				os.Exit(111)
+			}
 		}
 
 		// First things first, load the database into memory

--- a/boltbrowser.go
+++ b/boltbrowser.go
@@ -41,8 +41,8 @@ func main() {
 		currentFilename = databaseFile
 		db, err = bolt.Open(databaseFile, 0600, nil)
 		if err != nil {
-			fmt.Printf("Error reading file: %q\n", err.Error())
-			os.Exit(1)
+			mainLoop(nil, style)
+			continue
 		}
 
 		// First things first, load the database into memory

--- a/screen_browser.go
+++ b/screen_browser.go
@@ -454,6 +454,12 @@ func (screen *BrowserScreen) moveCursorDown() bool {
 func (screen *BrowserScreen) performLayout() {}
 
 func (screen *BrowserScreen) drawScreen(style Style) {
+	if screen.db == nil {
+		screen.drawHeader(style)
+		screen.setMessage("Invalid DB. Press 'q' to quit, '?' for help")
+		screen.drawFooter(style)
+		return
+	}
 	if len(screen.db.buckets) == 0 && screen.mode&modeInsertBucket != modeInsertBucket {
 		// Force a bucket insert
 		screen.startInsertItemAtParent(typeBucket)


### PR DESCRIPTION
os.Exit doesn't 'return', and wont call 'defer' statements, and because the main func never 'returns' it never closes the termbox screen, leaving the terminal in need of a 'reset'

With this change, 

*If multiple db are opened*, a simple message is displayed, and the user must press 'q' or 'ctrl+c' to continue to next DB properly. 

*In the case of a single DB*, just display the error *after* closing screen and *then* os.Exit(111)