### PR TITLE
Add flags support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ boltbrowser
 
 # Test Database
 test.db
+*.db

--- a/boltbrowser.go
+++ b/boltbrowser.go
@@ -33,7 +33,7 @@ func main() {
 
 	if flag.NArg() == 0 {
 		flag.Usage()
-		os.Exit(1)
+		os.Exit(2)
 	}
 
 	err = termbox.Init()

--- a/boltbrowser.go
+++ b/boltbrowser.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 
@@ -19,11 +20,19 @@ var memBolt *BoltDB
 
 var currentFilename string
 
+func init() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stdout, "Usage: %s <filename(s)>\n", ProgramName)
+	}
+}
+
 func main() {
 	var err error
 
-	if len(os.Args) < 2 {
-		fmt.Printf("Usage: %s <filename(s)>\n", ProgramName)
+	flag.Parse()
+
+	if flag.NArg() == 0 {
+		flag.Usage()
 		os.Exit(1)
 	}
 
@@ -35,7 +44,7 @@ func main() {
 	style := defaultStyle()
 	termbox.SetOutputMode(termbox.Output256)
 
-	databaseFiles := os.Args[1:]
+	databaseFiles := flag.Args()
 	for _, databaseFile := range databaseFiles {
 		currentFilename = databaseFile
 		db, err = bolt.Open(databaseFile, 0600, nil)


### PR DESCRIPTION
Currently executing `boltbrowser --help` creates a file with name `--help` in the current working directory, which is counterintuitive. This commit adds command-line flags support to boltbrowser and changes it to print out the usage message instead.
I also changed the exit code returned in case of an empty database files list to make it following [the convention](http://www.tldp.org/LDP/abs/html/exitcodes.html).