### PR TITLE
Timeout if DB is locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ Just provide a BoltDB filename to be opened as the first argument on the command
 ```sh
 boltbrowser <filename>
 ```
+
+To see all options that are available, run:
+
+```
+boltbrowser --help
+```

--- a/boltbrowser.go
+++ b/boltbrowser.go
@@ -23,9 +23,15 @@ var currentFilename string
 
 const DefaultDBOpenTimeout = time.Second
 
+var args struct {
+	DBOpenTimeout time.Duration
+}
+
 func init() {
+	flag.DurationVar(&args.DBOpenTimeout, "timeout", DefaultDBOpenTimeout, "DB file open timeout")
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stdout, "Usage: %s <filename(s)>\n", ProgramName)
+		fmt.Fprintf(os.Stdout, "Usage: %s [OPTIONS] <filename(s)>\nOptions:\n", ProgramName)
+		flag.PrintDefaults()
 	}
 }
 
@@ -50,7 +56,7 @@ func main() {
 	databaseFiles := flag.Args()
 	for _, databaseFile := range databaseFiles {
 		currentFilename = databaseFile
-		db, err = bolt.Open(databaseFile, 0600, &bolt.Options{Timeout: DefaultDBOpenTimeout})
+		db, err = bolt.Open(databaseFile, 0600, &bolt.Options{Timeout: args.DBOpenTimeout})
 		if err == bolt.ErrTimeout {
 			termbox.Close()
 			fmt.Printf("File %s is locked. Make sure it's not used by another app and try again\n", databaseFile)

--- a/boltbrowser.go
+++ b/boltbrowser.go
@@ -30,7 +30,7 @@ var args struct {
 func init() {
 	flag.DurationVar(&args.DBOpenTimeout, "timeout", DefaultDBOpenTimeout, "DB file open timeout")
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stdout, "Usage: %s [OPTIONS] <filename(s)>\nOptions:\n", ProgramName)
+		fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS] <filename(s)>\nOptions:\n", ProgramName)
 		flag.PrintDefaults()
 	}
 }


### PR DESCRIPTION
This PR adds a timeout option to open DB file. By default it it's 1 second, however this value can be overridden with `--timeout=` flag. Passing `--timeout=0` disables this functionality and makes `bolt.Open()` waiting indefinitely.

Closes #18 