### PR TITLE
Print only valid (non control) UTF8 characters

### DIFF
--- a/mainloop_windows.go
+++ b/mainloop_windows.go
@@ -1,3 +1,4 @@
+// +build windows
 package main
 
 // Windows doesn't support process backgrounding like *nix.

--- a/screen_browser.go
+++ b/screen_browser.go
@@ -595,9 +595,9 @@ func (screen *BrowserScreen) drawRightPane(style Style) {
 			} else if p != nil {
 				pathString := fmt.Sprintf("Path: %s", strings.Join(p.GetPath(), " → "))
 				startY += screen.drawMultilineText(pathString, 6, startX, startY, (w/2)-1, style.defaultFg, style.defaultBg)
-				keyString := fmt.Sprintf("Key: %s", p.key)
+				keyString := fmt.Sprintf("Key: %s", stringify([]byte(p.key)))
 				startY += screen.drawMultilineText(keyString, 5, startX, startY, (w/2)-1, style.defaultFg, style.defaultBg)
-				valString := fmt.Sprintf("Value: %s", p.val)
+				valString := fmt.Sprintf("Value: %s", stringify([]byte(p.val)))
 				startY += screen.drawMultilineText(valString, 7, startX, startY, (w/2)-1, style.defaultFg, style.defaultBg)
 			}
 		} else {
@@ -671,7 +671,7 @@ func (screen *BrowserScreen) drawPair(bp *BoltPair, style Style, y int) int {
 
 	prefixSpaces := strings.Repeat(" ", len(bp.GetPath())*2)
 	pairString := prefixSpaces
-	pairString = fmt.Sprintf("%s%s: %s", pairString, bp.key, bp.val)
+	pairString = fmt.Sprintf("%s%s: %s", pairString, stringify([]byte(bp.key)), stringify([]byte(bp.val)))
 	if len(pairString) > w {
 	}
 	prefixSpaces = prefixSpaces + "  "

--- a/stringify.go
+++ b/stringify.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unicode/utf8"
+)
+
+// stringify ensures that we can print only valid characters.
+// It's wrong to assume that everything is a string, since BoltDB is typeless.
+func stringify(v []byte) string {
+	if utf8.Valid(v) {
+		ok := true
+		for _, r := range string(v) {
+			if r < 0x20 {
+				ok = false
+				break
+			} else if r >= 0x7f && r <= 0x9f {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return string(v)
+		}
+	}
+	if len(v) == 8 {
+		return fmt.Sprintf("%v", binary.BigEndian.Uint64(v))
+	}
+
+	return fmt.Sprintf("%x", v)
+}


### PR DESCRIPTION
This PR adds a function that checks if the key/value contains non printable UTF8 characters. If it doesn't, it prints the hexadecimal value of the byte array.

![stringify](https://user-images.githubusercontent.com/1563110/35688100-86f04aaa-0757-11e8-8cd6-e3ed041345b6.png)