### PR TITLE
Fix Vendoring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tbrent/boltbrowser
+module github.com/br0xen/boltbrowser
 
 require (
 	github.com/boltdb/bolt v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module git.bullercodeworks.com/brian/boltbrowser
+module github.com/tbrent/boltbrowser
 
 require (
 	github.com/boltdb/bolt v1.3.1


### PR DESCRIPTION
Vendoring is broken. `go.mod` should either be modified to be for module `github.com/br0xen/boltbrowser` or the README.md needs to be changed to use `git.bullercodeworks.com/brian/boltbrowser`. I think the former is better since that's where most people interact with the project. 