### PR TITLE
add -no-value option

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ const DefaultDBOpenTimeout = time.Second
 var AppArgs struct {
 	DBOpenTimeout time.Duration
 	ReadOnly      bool
+	NoValue       bool
 }
 
 func init() {
@@ -63,6 +64,10 @@ func parseArgs() {
 				if val == "true" {
 					AppArgs.ReadOnly = true
 				}
+			case "-no-value":
+				if val == "true" {
+					AppArgs.NoValue = true
+				}
 			case "-help":
 				printUsage(nil)
 			default:
@@ -73,6 +78,8 @@ func parseArgs() {
 			switch parms[i] {
 			case "-readonly", "-ro":
 				AppArgs.ReadOnly = true
+			case "-no-value":
+				AppArgs.NoValue = true
 			case "-help":
 				printUsage(nil)
 			default:
@@ -89,6 +96,7 @@ func printUsage(err error) {
 	fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS] <filename(s)>\nOptions:\n", ProgramName)
 	fmt.Fprintf(os.Stderr, "  -timeout=duration\n        DB file open timeout (default 1s)\n")
 	fmt.Fprintf(os.Stderr, "  -ro, -readonly   \n        Open the DB in read-only mode\n")
+	fmt.Fprintf(os.Stderr, "  -no-value        \n        Do not display a value in left pane\n")
 }
 
 func main() {

--- a/screen_browser.go
+++ b/screen_browser.go
@@ -684,7 +684,12 @@ func (screen *BrowserScreen) bucketToLines(bkt *BoltBucket, style Style) []Line 
 				pfg, pbg = style.cursorFg, style.cursorBg
 			}
 			prPrefix := strings.Repeat(" ", len(bp.GetPath())*2)
-			pairString := fmt.Sprintf("%s%s: %s", prPrefix, stringify([]byte(bp.key)), stringify([]byte(bp.val)))
+			var pairString string
+			if AppArgs.NoValue {
+				pairString = fmt.Sprintf("%s%s", prPrefix, stringify([]byte(bp.key)))
+			} else {
+				pairString = fmt.Sprintf("%s%s: %s", prPrefix, stringify([]byte(bp.key)), stringify([]byte(bp.val)))
+			}
 			ret = append(ret, Line{pairString, pfg, pbg})
 		}
 	} else {


### PR DESCRIPTION
The long value makes a scroll too slow. `-no-value` doesn't show values in the left pane. We can see the value in the right pane.

![image](https://user-images.githubusercontent.com/2253692/71355636-57615d00-2588-11ea-8313-10766012d4f8.png)
