### PR TITLE
Update build tag to latest format

### DIFF
--- a/mainloop_windows.go
+++ b/mainloop_windows.go
@@ -1,4 +1,5 @@
-// +build windows
+//go:build windows
+
 package main
 
 // Windows doesn't support process backgrounding like *nix.


### PR DESCRIPTION
Fixes `go vet` to be clean.